### PR TITLE
Fix spelling in rta comments

### DIFF
--- a/src/rawtoaces_idt/rta.cpp
+++ b/src/rawtoaces_idt/rta.cpp
@@ -137,7 +137,7 @@ void Illum::setIllumIndex( const double &index )
 //      const char *: type of light source if user specifies
 //
 //	outputs:
-//		int: If successufully parsed, private data members (e.g., _data)
+//		int: If successfully parsed, private data members (e.g., _data)
 //           will be filled and return 1; Otherwise, return 0
 
 int Illum::readSPD( const string &path, const string &type )
@@ -254,7 +254,7 @@ vector<double> Illum::cctToxy( const double &cctd ) const
 //      const int: cct / correlated color temperature
 //
 //	outputs:
-//		int: If successufully processed, private data members (e.g., _data)
+//		int: If successfully processed, private data members (e.g., _data)
 //           will be filled and return 1; Otherwise, return 0
 
 void Illum::calDayLightSPD( const int &cct )
@@ -392,7 +392,7 @@ const double Illum::getIllumIndex() const
 //      const int: temp / temperature
 //
 //	outputs:
-//		int: If successufully processed, private data members (e.g., _data)
+//		int: If successfully processed, private data members (e.g., _data)
 //           will be filled and return 1; Otherwise, return 0
 
 void Illum::calBlackBodySPD( const int &cct )
@@ -858,7 +858,7 @@ void Idt::scaleLSC( Illum &Illuminant )
 //      const char *: camera model  (from libraw)
 //
 //	outputs:
-//		boolean: If successufully parsed, _cameraSpst will be filled and return 1;
+//		boolean: If successfully parsed, _cameraSpst will be filled and return 1;
 //               Otherwise, return 0
 
 int Idt::loadCameraSpst(
@@ -876,7 +876,7 @@ int Idt::loadCameraSpst(
 //      string: type of light source if user specifies
 //
 //	outputs:
-//		int: If successufully parsed, _bestIllum will be filled and return 1;
+//		int: If successfully parsed, _bestIllum will be filled and return 1;
 //               Otherwise, return 0
 
 int Idt::loadIlluminant( const vector<string> &paths, string type )
@@ -965,7 +965,7 @@ int Idt::loadIlluminant( const vector<string> &paths, string type )
 //		string : path to the 190-patch training data
 //
 //	outputs:
-//		_trainingSpec: If successufully parsed, _trainingSpec will be filled
+//		_trainingSpec: If successfully parsed, _trainingSpec will be filled
 
 void Idt::loadTrainingData( const string &path )
 {
@@ -1012,7 +1012,7 @@ void Idt::loadTrainingData( const string &path )
 //		string : path to the CIE 1931 Color Matching Functions data
 //
 //	outputs:
-//		_cmf: If successufully parsed, _cmf will be filled
+//		_cmf: If successfully parsed, _cmf will be filled
 
 void Idt::loadCMF( const string &path )
 {


### PR DESCRIPTION
## Summary
- Correct spelling of "successfully" in several comment blocks across `rta.cpp`

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "AcesContainer")*
- `cmake --build build` *(fails: No rule to make target 'Makefile')*
- `ctest --test-dir build` *(fails: No tests were found)*

------
https://chatgpt.com/codex/tasks/task_e_6896e9a9816c8328a3623df953d690b4