### PR TITLE
Fix getWLIncrement return type

### DIFF
--- a/include/rawtoaces/rta.h
+++ b/include/rawtoaces/rta.h
@@ -152,7 +152,7 @@ public:
 
     const char          *getBrand() const;
     const char          *getModel() const;
-    const uint8_t        getWLIncrement() const;
+    int                  getWLIncrement() const;
     const vector<RGBSen> getSensitivity() const;
 
     char *getBrand();

--- a/src/rawtoaces_idt/rta.cpp
+++ b/src/rawtoaces_idt/rta.cpp
@@ -514,10 +514,10 @@ const char *Spst::getModel() const
 //      N/A
 //
 //	outputs:
-//		const uint8_t: Wavelength increment value (e.g., 5nm, 10nm) of
+//		int: Wavelength increment value (e.g., 5nm, 10nm) of
 //                     the camera sensitivity
 
-const uint8_t Spst::getWLIncrement() const
+int Spst::getWLIncrement() const
 {
     return _increment;
 }
@@ -571,7 +571,7 @@ char *Spst::getModel()
 //      N/A
 //
 //	outputs:
-//	    uint8_t: Wavelength increment value (e.g., 5nm, 10nm) of the
+//	    int: Wavelength increment value (e.g., 5nm, 10nm) of the
 //               camera's sensitivity
 
 int Spst::getWLIncrement()


### PR DESCRIPTION
## Summary
- return `int` from both `Spst::getWLIncrement` overloads to avoid narrowing

## Testing
- `cmake -S . -B build` *(fails: Could not find AcesContainer)*

------
https://chatgpt.com/codex/tasks/task_e_6896e82bd60c8328865d89b4d332c6ca