### PR TITLE
docs: update package contents in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,13 +23,14 @@ The output image complies with the ACES Container specification [(SMPTE S2065-4)
 
 The source code contains the following:
 
-* [`cmake/`](./cmake) - CMake modules for locating dependencies (e.g., `libraw `)
+* [`build_scripts/`](./build_scripts) - Helper scripts for installing dependencies
+* [`cmake/`](./cmake) - CMake modules for locating dependencies (e.g., `libraw`)
 * [`config/`](./config) - CMake configuration files
 * [`data/`](./data) - Data files containing camera sensitivity, light source, color matching function and 190 training patch data
-* [`lib/`](./lib) - IDT and math libraries
-* [`src/`](./src) - AcesRender wrapper library and C++ header file containing `rawtoaces` usage information
-* [`test/`](./test) - Sample testing materials such as a ".NEF" RAW image and a camera spectral sensitivity data file
-* [`main.cpp`](main.cpp) - C++ source code file for call routines to process images
+* [`include/`](./include) - Public header files for the `rawtoaces` library
+* [`src/`](./src) - Source code for `rawtoaces` utilities and IDT implementation
+* [`unittest/`](./unittest) - Unit tests for `rawtoaces`
+* [`main.cpp`](main.cpp) - C++ source file for call routines to process images
 
 ## Prerequisites
 


### PR DESCRIPTION
## Summary
- refresh Package Contents to reflect current directories and remove obsolete entries

## Testing
- `cmake -S . -B build` *(fails: Could not find AcesContainer)*
- `bash build_scripts/install_aces_container.bash` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_6896ec00b05083289714e05f09072750