### PR TITLE
Fix LibRaw camera list iteration

### DIFF
--- a/src/rawtoaces_util/acesrender.cpp
+++ b/src/rawtoaces_util/acesrender.cpp
@@ -2019,8 +2019,10 @@ const vector<string> AcesRender::getSupportedCameras() const
 void AcesRender::printLibRawCameras()
 {
     const char **cl = _rawProcessor->cameraList();
-    while ( *( cl + 1 ) != NULL )
+    while ( *cl != nullptr )
+    {
         printf( "%s\n", *cl++ );
+    }
 }
 
 //	=====================================================================


### PR DESCRIPTION
## Summary
- iterate LibRaw camera names until a `nullptr` sentinel
- ensure loop body uses braces for consistent style

## Testing
- `cmake -S . -B build` *(fails: Could not find package "AcesContainer")*
- `apt-get update` *(fails: repository not signed / 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6896ebddb43883289ef11df2bedf3eec